### PR TITLE
[SRM-77] CompletableFuture tuning

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.thymeleaf.prefix=classpath:/templates/
 spring.thymeleaf.suffix=.jsp
 spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false
+java.util.concurrent.ForkJoinPool.common.parallelism=16


### PR DESCRIPTION
Original task was "Convert CompleteableFuture usage to Spring TaskExecutor". Instead, I set the number of threads in the Common ForkJoinPool to 16, so that server with 2 CPUs don't have slow startups. Also, Added a single retry, and lowered the read timeout to 20s, so we can hit the retry quicker.

SRM-77