### PR TITLE
Fix erroneous/fake market listings ("11111..." Pubkey)

### DIFF
--- a/src/main/java/com/mmorrell/serumdata/manager/MarketManager.java
+++ b/src/main/java/com/mmorrell/serumdata/manager/MarketManager.java
@@ -214,6 +214,12 @@ public class MarketManager {
 
         for (ProgramAccount programAccount : programAccounts) {
             Market market = Market.readMarket(programAccount.getAccount().getDecodedData());
+
+            // Ignore fake/erroneous market accounts
+            if (market.getOwnAddress().equals(new PublicKey("11111111111111111111111111111111"))) {
+                continue;
+            }
+
             market.setBaseDecimals(
                     (byte) tokenManager.getDecimals(
                             market.getBaseMint()

--- a/src/main/java/com/mmorrell/serumdata/manager/MarketRankManager.java
+++ b/src/main/java/com/mmorrell/serumdata/manager/MarketRankManager.java
@@ -100,13 +100,15 @@ public class MarketRankManager {
         Map<PublicKey, Optional<AccountInfo.Value>> accountDataMap = new HashMap<>();
 
         for (List<PublicKey> publicKeys : marketIdsPartitioned) {
-            Map<PublicKey, Optional<AccountInfo.Value>> accountInfos = rpcClient.getApi().getMultipleAccountsMap(publicKeys);
+            Map<PublicKey, Optional<AccountInfo.Value>> accountInfos = rpcClient.getApi()
+                    .getMultipleAccountsMap(publicKeys);
             accountDataMap.putAll(accountInfos);
         }
 
-        marketListings.forEach(marketListing -> {
+        // iterate by index to debug
+        for (MarketListing marketListing : marketListings) {
             Optional<AccountInfo.Value> value = accountDataMap.get(marketListing.getId());
-            value.ifPresent(accountData -> {
+            if (value.isPresent()) {
                 Market market = Market.readMarket(
                         Base64.getDecoder().decode(
                                 value.get().getData().get(0)
@@ -120,8 +122,8 @@ public class MarketRankManager {
                                 marketListing.getQuoteDecimals()
                         )
                 );
-            });
-        });
+            }
+        }
 
         LOGGER.info("Market listings updated.");
     }


### PR DESCRIPTION
There was ~3 weird markets on the /markets page, which had an address of `11111111111111111111111111111111`.

These accounts are of 388 length, and owned by Serum, so returned by GPA, but have no meaningful data. Possibly a security researcher, or glitch. 

Side note: Pentest account schemes on serum