### PR TITLE
[SRM-124] Fix token symbol permalinking

### DIFF
--- a/src/main/java/com/mmorrell/serumdata/controller/IndexController.java
+++ b/src/main/java/com/mmorrell/serumdata/controller/IndexController.java
@@ -127,8 +127,12 @@ public class IndexController {
             for (Token baseToken : possibleBaseTokens) {
                 // compile list of markets, return one with most fees accrued.
                 Optional<Market> optionalMarket = marketRankManager.getMostActiveMarket(baseToken.getPublicKey());
-                optionalMarket.ifPresent(activeMarkets::add);
-
+                if (optionalMarket.isPresent()) {
+                    Market foundMarket = optionalMarket.get();
+                    if (foundMarket.getBaseMint().equals(baseToken.getPublicKey())) {
+                        activeMarkets.add(foundMarket);
+                    }
+                }
             }
             activeMarkets.sort(Comparator.comparingLong(Market::getQuoteFeesAccrued).reversed());
 

--- a/src/main/java/com/mmorrell/serumdata/manager/MarketManager.java
+++ b/src/main/java/com/mmorrell/serumdata/manager/MarketManager.java
@@ -171,6 +171,11 @@ public class MarketManager {
         return new ArrayList<>(marketCache.values());
     }
 
+    public List<Market> getMarketsByBaseMint(PublicKey tokenMint) {
+        final Set<Market> result = new HashSet<>(marketMapCache.getOrDefault(tokenMint, new ArrayList<>()));
+        return new ArrayList<>(result);
+    }
+
     public List<Market> getMarketsByTokenMint(PublicKey tokenMint) {
         final Set<Market> result = new HashSet<>();
 

--- a/src/main/java/com/mmorrell/serumdata/manager/MarketRankManager.java
+++ b/src/main/java/com/mmorrell/serumdata/manager/MarketRankManager.java
@@ -85,7 +85,7 @@ public class MarketRankManager {
     }
 
     public Optional<Market> getMostActiveMarket(PublicKey baseMint) {
-        List<Market> markets = marketManager.getMarketsByTokenMint(baseMint);
+        List<Market> markets = marketManager.getMarketsByBaseMint(baseMint);
         if (markets.size() < 1) {
             return Optional.empty();
         }


### PR DESCRIPTION
- Fix permalinking such as `/SRM` or `/RAY`, which would previously choose a quote-paired market, when only wanting base-paired.